### PR TITLE
Allows lefthook to work when node_modules is not in root folder for n…

### DIFF
--- a/cmd/templates/hook.tmpl
+++ b/cmd/templates/hook.tmpl
@@ -21,7 +21,7 @@ call_lefthook()
   elif bundle exec lefthook -h >/dev/null 2>&1
   then
     bundle exec lefthook $1
-  elif npx lefthook -h >/dev/null 2>&1
+  elif npx @arkweid/lefthook -h >/dev/null 2>&1
   then
     npx lefthook $1
   elif yarn lefthook -h >/dev/null 2>&1


### PR DESCRIPTION
…px (#224)

npx will automatically install the module if not present. yarn does not do this and complains when the package.json is not found.